### PR TITLE
Replace `var` with `final` keyword & Fix typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 # See https://www.dartlang.org/guides/libraries/private-files
 
-# Local Android Studio config
-.idea
-
 # Files and directories created by pub
 .dart_tool/
 .packages

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://www.dartlang.org/guides/libraries/private-files
 
+# Local Android Studio config
+.idea
+
 # Files and directories created by pub
 .dart_tool/
 .packages

--- a/lib/agents.dart
+++ b/lib/agents.dart
@@ -29,8 +29,8 @@ class FirstMover extends Agent {
 }
 
 Move _findRandomMove(Iterable<Move> legalMoves) {
-  var rng = Random();
-  var choices = legalMoves.toList();
+  final rng = Random();
+  final List<Move> choices = legalMoves.toList();
   return choices[rng.nextInt(choices.length)];
 }
 
@@ -51,9 +51,9 @@ class Fixate extends Agent {
   Delta? favorite;
 
   Move? getMatchingFavorite(List<Move> legalMoves) {
-    var favorite = this.favorite;
+    Delta? favorite = this.favorite;
     if (favorite != null) {
-      for (var move in legalMoves) {
+      for (final move in legalMoves) {
         if (move.delta == favorite) {
           return move;
         }
@@ -71,18 +71,18 @@ class Fixate extends Agent {
   @override
   void paint(Canvas canvas, Rect rect, PieceType type) {
     super.paint(canvas, rect, type);
-    var favorite = this.favorite;
+    final favorite = this.favorite;
     if (favorite != null) {
-      var paint = Paint();
+      final paint = Paint();
       paint.color = Colors.brown.shade900;
       paint.style = PaintingStyle.stroke;
       paint.strokeWidth = 4.0;
-      var center = rect.center;
-      var offset = Offset(1.0 * favorite.dx, 1.0 * favorite.dy);
+      final center = rect.center;
+      Offset offset = Offset(1.0 * favorite.dx, 1.0 * favorite.dy);
       offset /= offset.distance;
-      var target = center +
+      final target = center +
           Offset(offset.dx * rect.width / 2.0, offset.dy * rect.height / 2.0);
-      var path = Path();
+      final path = Path();
       path.moveTo(center.dx, center.dy);
       path.lineTo(target.dx, target.dy);
       canvas.drawPath(path, paint);
@@ -91,8 +91,8 @@ class Fixate extends Agent {
 
   @override
   Move pickMove(AgentView view) {
-    var legalMoves = view.legalMoves.toList();
-    var move = getMatchingFavorite(legalMoves) ?? _findRandomMove(legalMoves);
+    final legalMoves = view.legalMoves.toList();
+    final move = getMatchingFavorite(legalMoves) ?? _findRandomMove(legalMoves);
     favorite = move.delta;
     return move;
   }
@@ -102,8 +102,8 @@ Move _findMoveByDistanceToTarget(AgentView view, Position targetPosition,
     bool Function(double currentDistance, double bestDistance) isBetter) {
   Move? bestMove;
   double? bestDistance;
-  for (var move in view.legalMoves) {
-    var currentDistance = move.finalPosition.deltaTo(targetPosition).magnitude;
+  for (final move in view.legalMoves) {
+    final currentDistance = move.finalPosition.deltaTo(targetPosition).magnitude;
     if (bestDistance == null || isBetter(currentDistance, bestDistance)) {
       bestDistance = currentDistance;
       bestMove = move;
@@ -124,27 +124,27 @@ class Seeker extends Agent {
   @override
   void paint(Canvas canvas, Rect rect, PieceType type) {
     super.paint(canvas, rect, type);
-    var target = this.target;
+    final target = this.target;
     if (target != null) {
-      var paint = Paint();
+      final paint = Paint();
       paint.color = color;
       paint.style = PaintingStyle.stroke;
       paint.strokeWidth = 4.0;
-      var offset = Offset(target.dx * rect.width, target.dy * rect.height);
-      var reticle = rect.translate(offset.dx, offset.dy);
+      final offset = Offset(target.dx * rect.width, target.dy * rect.height);
+      final reticle = rect.translate(offset.dx, offset.dy);
       canvas.drawOval(reticle.inflate(3.0), paint);
     }
   }
 
   @override
   Move pickMove(AgentView view) {
-    var initialPosition = view.getPositions(PieceType.king).first;
-    var targetPosition = view.closestOpponent(initialPosition, PieceType.king);
+    final initialPosition = view.getPositions(PieceType.king).first;
+    final targetPosition = view.closestOpponent(initialPosition, PieceType.king);
     if (targetPosition == null) {
       target = null;
       return _findRandomMove(view.legalMoves);
     }
-    var move = _findMoveByDistanceToTarget(view, targetPosition,
+    final move = _findMoveByDistanceToTarget(view, targetPosition,
         (double currentDistance, double bestDistance) {
       return currentDistance < bestDistance;
     });
@@ -213,8 +213,8 @@ class Runner extends Agent {
 
   @override
   Move pickMove(AgentView view) {
-    var initialPosition = view.getPositions(PieceType.king).first;
-    var targetPosition = view.closestOpponent(initialPosition, PieceType.king);
+    final initialPosition = view.getPositions(PieceType.king).first;
+    final targetPosition = view.closestOpponent(initialPosition, PieceType.king);
     if (targetPosition == null) {
       return _findRandomMove(view.legalMoves);
     }
@@ -234,12 +234,12 @@ class Opportunist extends Agent {
 
   @override
   Move pickMove(AgentView view) {
-    var initialPosition = view.getPositions(PieceType.king).first;
-    var targetPosition = view.closestOpponent(initialPosition, PieceType.king);
+    final initialPosition = view.getPositions(PieceType.king).first;
+    final targetPosition = view.closestOpponent(initialPosition, PieceType.king);
     if (targetPosition == null) {
       return _findRandomMove(view.legalMoves);
     }
-    for (var move in view.legalMoves) {
+    for (final move in view.legalMoves) {
       if (move.finalPosition == targetPosition) {
         return move;
       }

--- a/lib/engine.dart
+++ b/lib/engine.dart
@@ -34,7 +34,7 @@ class Position {
   const Position(this.x, this.y);
 
   factory Position.random() {
-    var rng = Random();
+    final rng = Random();
     return Position(rng.nextInt(Board.kWidth), rng.nextInt(Board.kHeight));
   }
 
@@ -95,7 +95,7 @@ abstract class Player {
   const Player();
 
   void paint(Canvas canvas, Rect rect, PieceType type) {
-    var paint = Paint();
+    final Paint paint = Paint();
     paint.style = PaintingStyle.fill;
     paint.color = color;
     switch (type) {
@@ -159,8 +159,8 @@ class Board {
     _pieces.forEach(callback);
   }
 
-  Board placeAt(Position postion, Piece piece) {
-    return Board._(<Position, Piece>{postion: piece, ..._pieces});
+  Board placeAt(Position position, Piece piece) {
+    return Board._(<Position, Piece>{position: piece, ..._pieces});
   }
 
   Piece? getAt(Position position) {
@@ -168,7 +168,7 @@ class Board {
   }
 
   Board move(Player player, Move move) {
-    var piece = getAt(move.initialPosition);
+    final piece = getAt(move.initialPosition);
     if (piece == null) {
       throw IllegalMove('No piece at ${move.initialPosition}.');
     }
@@ -184,14 +184,14 @@ class Board {
       throw IllegalMove(
           'Pieces at ${move.initialPosition} and ${move.finalPosition} have the same owner.');
     }
-    var newPieces = <Position, Piece>{..._pieces};
+    final newPieces = <Position, Piece>{..._pieces};
     newPieces.remove(move.initialPosition);
     newPieces[move.finalPosition] = piece;
     return Board._(newPieces);
   }
 
   bool isLegalMove(Player player, Move move) {
-    var piece = getAt(move.initialPosition);
+    final piece = getAt(move.initialPosition);
     return piece != null &&
         piece.owner == player &&
         _canMovePieceTo(piece, move.finalPosition);
@@ -202,13 +202,13 @@ class Board {
   }
 
   Iterable<Move> getLegalMoves(Player player) sync* {
-    for (var position in _pieces.keys) {
-      var piece = getAt(position);
+    for (final position in _pieces.keys) {
+      final piece = getAt(position);
       if (piece == null || piece.owner != player) {
         continue;
       }
-      for (var delta in piece.deltas) {
-        var move = position.move(delta);
+      for (final delta in piece.deltas) {
+        final move = position.move(delta);
         if (_canMovePieceTo(piece, move.finalPosition)) {
           assert(isLegalMove(player, move));
           yield move;
@@ -218,7 +218,7 @@ class Board {
   }
 
   bool hasPieceOfType(Player player, PieceType type) {
-    for (var piece in _pieces.values) {
+    for (final piece in _pieces.values) {
       if (piece.owner == player && piece.type == type) {
         return true;
       }
@@ -246,11 +246,11 @@ class GameState {
   GameState.empty() : this(Board.empty(), const <Player>[], const <Player>[]);
 
   GameState move(Move move) {
-    var newBoard = board.move(activePlayer, move);
-    var newPlayers = <Player>[];
-    var newDeadPlayers = List<Player>.from(deadPlayers);
-    for (var i = 1; i < players.length; ++i) {
-      var player = players[i];
+    final newBoard = board.move(activePlayer, move);
+    final newPlayers = <Player>[];
+    final newDeadPlayers = List<Player>.from(deadPlayers);
+    for (int i = 1; i < players.length; ++i) {
+      final player = players[i];
       if (newBoard.isAlive(player)) {
         newPlayers.add(player);
       } else {
@@ -258,8 +258,8 @@ class GameState {
       }
     }
     newPlayers.add(activePlayer);
-    var newTurnsUntilDraw = turnsUntilDraw - 1;
-    var playerDied = players.length != newPlayers.length;
+    int newTurnsUntilDraw = turnsUntilDraw - 1;
+    bool playerDied = players.length != newPlayers.length;
     if (playerDied) {
       newTurnsUntilDraw = turnsUntilDrawDefault;
     }
@@ -313,7 +313,7 @@ class AgentView {
       if (piece.owner == _player || piece.type != type) {
         return;
       }
-      var currentDistance = position.deltaTo(currentPosition).magnitude;
+      double currentDistance = position.deltaTo(currentPosition).magnitude;
       if (currentDistance < bestDistance) {
         bestDistance = currentDistance;
         bestPosition = currentPosition;
@@ -335,7 +335,7 @@ class GameHistory {
   final Map<String, double> rating = <String, double>{};
 
   double expectedScore(double currentRating, double opponentRating) {
-    var exponent = (opponentRating - currentRating) / 400.0;
+    double exponent = (opponentRating - currentRating) / 400.0;
     return 1.0 / (1.0 + pow(10.0, exponent));
   }
 
@@ -354,37 +354,37 @@ class GameHistory {
   }
 
   void updateRating(Player winner, Player loser, double score) {
-    var winnerRating = currentRating(winner);
-    var loserRating = currentRating(loser);
-    var stake =
+    double winnerRating = currentRating(winner);
+    double loserRating = currentRating(loser);
+    double stake =
         pointsToTransfer(score, expectedScore(winnerRating, loserRating));
     adjustRating(winner, stake);
     adjustRating(loser, -stake);
   }
 
   void recordGame(GameState gameState) {
-    var pointsPerPlayer = 1.0 / gameState.players.length;
-    for (var player in gameState.players) {
-      var name = player.name;
+    double pointsPerPlayer = 1.0 / gameState.players.length;
+    for (final player in gameState.players) {
+      String name = player.name;
       wins[name] = (wins[name] ?? 0.0) + pointsPerPlayer;
       gameCount += 1;
     }
     // http://www.tckerrigan.com/Misc/Multiplayer_Elo/
     // record dead players as losing against the next dead.
-    for (var i = 0; i < gameState.deadPlayers.length - 1; i++) {
-      var winner = gameState.deadPlayers[i + 1];
-      var loser = gameState.deadPlayers[i];
+    for (int i = 0; i < gameState.deadPlayers.length - 1; i++) {
+      final Player winner = gameState.deadPlayers[i + 1];
+      final Player loser = gameState.deadPlayers[i];
       updateRating(winner, loser, 1.0); // win
     }
-    var alivePlayers = List.from(gameState.players);
+    final List alivePlayers = List.from(gameState.players);
     alivePlayers.shuffle();
     // record last dead player as losing against random alive player?
     if (gameState.deadPlayers.isNotEmpty) {
       updateRating(alivePlayers.first, gameState.deadPlayers.last, 1.0); // win
     }
     // record alive players in a cycle of draws.
-    for (var i = 0; i < alivePlayers.length; i++) {
-      for (var j = i + 1; j < alivePlayers.length; j++) {
+    for (int i = 0; i < alivePlayers.length; i++) {
+      for (int j = i + 1; j < alivePlayers.length; j++) {
         updateRating(alivePlayers[i], alivePlayers[j], 0.5); // draw
       }
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -119,7 +119,7 @@ class BoardView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var winner = gameState.winner;
+    final winner = gameState.winner;
     return Stack(
       fit: StackFit.expand,
       children: [
@@ -139,7 +139,7 @@ class BoardPainter extends CustomPainter {
   BoardPainter(this.gameState);
 
   void paintBackground(Canvas canvas, Size size, Size cell) {
-    var paint = Paint();
+    final paint = Paint();
     paint.style = PaintingStyle.fill;
     for (int i = 0; i < Board.kWidth; ++i) {
       for (int j = 0; j < Board.kHeight; ++j) {
@@ -162,7 +162,7 @@ class BoardPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    var cellSize = Size(size.width / Board.kWidth, size.height / Board.kHeight);
+    final cellSize = Size(size.width / Board.kWidth, size.height / Board.kHeight);
     paintBackground(canvas, size, cellSize);
     paintPieces(canvas, size, cellSize);
   }
@@ -181,14 +181,14 @@ class GameController {
   GameController.withAgents(this._agents);
 
   factory GameController.withRandomAgents(int numberOfPlayers) {
-    var rng = Random();
+    final rng = Random();
     return GameController.withAgents(List<Agent>.generate(numberOfPlayers,
         (index) => agents.all[rng.nextInt(agents.all.length)]()));
   }
 
   GameState getRandomInitialGameState() {
-    var board = Board.empty();
-    for (var player in _agents) {
+    Board board = Board.empty();
+    for (final player in _agents) {
       Position position;
       do {
         position = Position.random();
@@ -200,9 +200,9 @@ class GameController {
   }
 
   GameState takeTurn(GameState gameState) {
-    var activePlayer = gameState.activePlayer;
-    var view = AgentView(gameState, activePlayer);
-    var activeAgent = activePlayer as Agent;
+    final activePlayer = gameState.activePlayer;
+    final view = AgentView(gameState, activePlayer);
+    final activeAgent = activePlayer as Agent;
     return gameState.move(activeAgent.pickMove(view));
   }
 }
@@ -221,11 +221,11 @@ class LeaderBoard extends StatelessWidget {
           width: _kWidth, child: Text("Tap play to gather data."));
     }
     String asPercent(double value) {
-      var percent = (value / history.gameCount) * 100;
+      final percent = (value / history.gameCount) * 100;
       return "${percent.toStringAsFixed(1)}%";
     }
 
-    var entries = history.wins.entries.toList();
+    final entries = history.wins.entries.toList();
     entries.sort((lhs, rhs) => rhs.value.compareTo(lhs.value));
 
     return SizedBox(


### PR DESCRIPTION
A minor clean-up to replace all the `var` keywords with `final` within the three files.
In special cases where final doesn't apply, the datatype of the variable was used instead.

Typo fixed inside `engine.dart`
Before `postion`
After `position`